### PR TITLE
Beweis des Maximums und Minimums einer stetigen Funktion

### DIFF
--- a/Skript.tex
+++ b/Skript.tex
@@ -1538,7 +1538,7 @@
             Der Beweis von (a) $\equivalent$ (b) folgt direkt aus Satz~\ref{satz:stetigkeit-def-equiv}.\\
             (c) $\impl$ (a): Sei $U$ offen in $N$. Dann ist $f^{-1}\of{U}$ offen in $M$. Sei $x_0\in M$ beliebig und $\varepsilon > 0$. Dann ist
             \begin{align*}
-                B_{\varepsilon}^{N}&\coloneqq B_{\varepsilon}^{N}\of{f\of{x}} = \set{y\in N: d_N\of{y, f\of{x_0}} < \varepsilon}
+                B_{\varepsilon}^{N}&\coloneqq B_{\varepsilon}^{N}\of{f\of{x_0}} = \set{y\in N: d_N\of{y, f\of{x_0}} < \varepsilon}
                 \intertext{offen in $N$}
                 &\impl V=f^{-1}\of{B_{\varepsilon}^{N}} \text{ offen in }M\\
                 \intertext{Außerdem ist $x_0\in V$}

--- a/Skript.tex
+++ b/Skript.tex
@@ -1678,7 +1678,7 @@
             \exists\ov{x}\in A\colon f\of{\ov{x}} &= \sup\set{f\of{x}: x\in A}
         \end{align*}
         \begin{proof}
-            \textsc{Schritt 1}: Sei $a\coloneqq\inf\set{f\of{x}: x\in A} > -\infty$. Angenommen $a=-\infty$. Dann würde gelten
+            \textsc{Schritt 1}: Sei $a\coloneqq\inf\set{f\of{x}: x\in A}$. Angenommen $a=-\infty$. Dann würde gelten
             \begin{align*}
                 &\forall n\in\N\ex x_0\in A\colon f\of{x_n} \leq -n\\
                 \intertext{Das heißt es existiert eine konvergente Teilfolge $(x_{n_k})_k$, da $A$ kompakt ist. Wir definieren $x \coloneqq \biglim{k\toinf} x_{n_k}\in A$. Wegen der Stetigkeit von $f$ gilt dann}


### PR DESCRIPTION
Die Definitition von a war widersprüchlich.
![image](https://github.com/rk-kit/Analysis-II-Hundertmark-KIT/assets/72506173/a39e63db-f56e-4477-a2de-5d47328dca87)
