### PR TITLE
Typo in der zweiten Ungleichung, da war x_n_k gemeint

### DIFF
--- a/Skript.tex
+++ b/Skript.tex
@@ -1792,7 +1792,7 @@
                 d_M\of{x_{n_k}, y} \leq d_M\of{x_{n_k}, y_{n_k}} + d_M\of{y_{n_k}, y} \fromto 0
                 \intertext{Da $f$ stetig ist folgt}
                 \impl d_N\of{f\of{x_{n_k}}, f\of{y}}\fromto 0 \text{ für } k\toinf\\
-                0 < \varepsilon \leq d_N\of{f\of{x_{n_j}}, f\of{y_{n_k}}} \leq d_N\of{f\of{x_{n_k}}, f\of{y}} + d_N\of{f\of{y}, f\of{y_{n_k}}}\fromto 0
+                0 < \varepsilon \leq d_N\of{f\of{x_{n_k}}, f\of{y_{n_k}}} \leq d_N\of{f\of{x_{n_k}}, f\of{y}} + d_N\of{f\of{y}, f\of{y_{n_k}}}\fromto 0
             \end{align*}
             Damit ergibt sich ein Widerspruch, da $\varepsilon$ fest gewählt war.
         \end{proof}

--- a/Skript.tex
+++ b/Skript.tex
@@ -1538,7 +1538,7 @@
             Der Beweis von (a) $\equivalent$ (b) folgt direkt aus Satz~\ref{satz:stetigkeit-def-equiv}.\\
             (c) $\impl$ (a): Sei $U$ offen in $N$. Dann ist $f^{-1}\of{U}$ offen in $M$. Sei $x_0\in M$ beliebig und $\varepsilon > 0$. Dann ist
             \begin{align*}
-                B_{\varepsilon}^{N}&\coloneqq B_{\varepsilon}^{N}\of{f\of{x}} = \set{y\in N: d_N\of{y, f\of{x_0}} < \varepsilon}
+                B_{\varepsilon}^{N}&\coloneqq B_{\varepsilon}^{N}\of{f\of{x_0}} = \set{y\in N: d_N\of{y, f\of{x_0}} < \varepsilon}
                 \intertext{offen in $N$}
                 &\impl V=f^{-1}\of{B_{\varepsilon}^{N}} \text{ offen in }M\\
                 \intertext{Außerdem ist $x_0\in V$}

--- a/Skript.tex
+++ b/Skript.tex
@@ -1678,7 +1678,7 @@
             \exists\ov{x}\in A\colon f\of{\ov{x}} &= \sup\set{f\of{x}: x\in A}
         \end{align*}
         \begin{proof}
-            \textsc{Schritt 1}: Sei $a\coloneqq\inf\set{f\of{x}: x\in A} > -\infty$. Angenommen $a=-\infty$. Dann würde gelten
+            \textsc{Schritt 1}: Sei $a\coloneqq\inf\set{f\of{x}: x\in A}$. Angenommen $a=-\infty$. Dann würde gelten
             \begin{align*}
                 &\forall n\in\N\ex x_0\in A\colon f\of{x_n} \leq -n\\
                 \intertext{Das heißt es existiert eine konvergente Teilfolge $(x_{n_k})_k$, da $A$ kompakt ist. Wir definieren $x \coloneqq \biglim{k\toinf} x_{n_k}\in A$. Wegen der Stetigkeit von $f$ gilt dann}


### PR DESCRIPTION
![image](https://github.com/rk-kit/Analysis-II-Hundertmark-KIT/assets/72506173/82106845-ade3-4ca0-bfd4-e01f93b50f4b)
